### PR TITLE
Extract and test signature logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
     <!-- Core Imposition Logic (Shared) -->
     <script src="src/imposition_logic.js"></script>
     <script src="src/layout_logic.js"></script>
+    <script src="src/signature_logic.js"></script>
     <style>
         /* Custom styles for a better look and feel */
         @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
@@ -156,38 +157,24 @@
          */
         function updateSignatureOptions(originalPageCount) {
             const separateCoverCheckbox = document.getElementById('separate-cover-flyleaf');
-            let adjustedPageCount = originalPageCount;
-
-            if (separateCoverCheckbox.checked && originalPageCount >= 2) {
-                adjustedPageCount += 2; 
-            }
-
-            let minBlanks = Infinity;
-            let bestSignatureSize = null;
 
             const options = signatureSizeSelect.getElementsByTagName('option');
+            const availableSizes = Array.from(options).map(o => parseInt(o.value, 10)).filter(v => !isNaN(v));
+
+            const result = SignatureLogic.calculateSignatureOptions(originalPageCount, separateCoverCheckbox.checked, availableSizes);
 
             for (const option of options) {
                 const sigSize = parseInt(option.value, 10);
                 if (isNaN(sigSize)) continue;
-
-                const numSheets = sigSize / 4;
-                const numSignatures = Math.ceil(adjustedPageCount / sigSize);
-                const totalPages = numSignatures * sigSize;
-                const blanksAdded = totalPages - adjustedPageCount;
                 
-                option.textContent = `${sigSize} pages (${numSheets} sheets) — ${numSignatures} sigs, adds ${blanksAdded} blank(s)`;
-
-                if (sigSize >= 16 && sigSize <= 32) {
-                    if (blanksAdded < minBlanks) {
-                        minBlanks = blanksAdded;
-                        bestSignatureSize = sigSize;
-                    }
+                const optionData = result.options.find(o => o.sigSize === sigSize);
+                if (optionData) {
+                    option.textContent = optionData.label;
                 }
             }
 
-            if (bestSignatureSize !== null) {
-                signatureSizeSelect.value = bestSignatureSize;
+            if (result.bestSignatureSize !== null) {
+                signatureSizeSelect.value = result.bestSignatureSize;
             }
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -434,7 +434,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -629,7 +628,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -1021,7 +1019,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/src/signature_logic.js
+++ b/src/signature_logic.js
@@ -1,0 +1,52 @@
+(function (global, factory) {
+    if (typeof module === "object" && typeof module.exports === "object") {
+        module.exports = factory();
+    } else {
+        global.SignatureLogic = factory();
+    }
+})(typeof self !== "undefined" ? self : this, function () {
+
+    function calculateSignatureOptions(originalPageCount, isFlyleafEnabled, availableSizes) {
+        let adjustedPageCount = originalPageCount;
+
+        if (isFlyleafEnabled && originalPageCount >= 2) {
+            adjustedPageCount += 2;
+        }
+
+        let minBlanks = Infinity;
+        let bestSignatureSize = null;
+        const options = [];
+
+        for (const sigSize of availableSizes) {
+            if (isNaN(sigSize)) continue;
+
+            const numSheets = sigSize / 4;
+            const numSignatures = Math.ceil(adjustedPageCount / sigSize);
+            const totalPages = numSignatures * sigSize;
+            const blanksAdded = totalPages - adjustedPageCount;
+
+            options.push({
+                sigSize,
+                numSheets,
+                numSignatures,
+                totalPages,
+                blanksAdded,
+                label: `${sigSize} pages (${numSheets} sheets) — ${numSignatures} sigs, adds ${blanksAdded} blank(s)`
+            });
+
+            if (sigSize >= 16 && sigSize <= 32) {
+                if (blanksAdded < minBlanks) {
+                    minBlanks = blanksAdded;
+                    bestSignatureSize = sigSize;
+                }
+            }
+        }
+
+        return {
+            options,
+            bestSignatureSize
+        };
+    }
+
+    return { calculateSignatureOptions };
+});

--- a/src/signature_logic.js
+++ b/src/signature_logic.js
@@ -6,10 +6,15 @@
     }
 })(typeof self !== "undefined" ? self : this, function () {
 
-    function calculateSignatureOptions(originalPageCount, isFlyleafEnabled, availableSizes) {
-        let adjustedPageCount = originalPageCount;
+    function calculateSignatureOptions(originalPageCount, isFlyleafEnabled, availableSizes = []) {
+        const pageCount = parseInt(originalPageCount, 10);
+        if (isNaN(pageCount) || pageCount < 0) {
+            return { options: [], bestSignatureSize: null };
+        }
 
-        if (isFlyleafEnabled && originalPageCount >= 2) {
+        let adjustedPageCount = pageCount;
+
+        if (isFlyleafEnabled && pageCount >= 2) {
             adjustedPageCount += 2;
         }
 
@@ -17,7 +22,8 @@
         let bestSignatureSize = null;
         const options = [];
 
-        for (const sigSize of availableSizes) {
+        const sizes = Array.isArray(availableSizes) ? availableSizes : [];
+        for (const sigSize of sizes) {
             if (isNaN(sigSize)) continue;
 
             const numSheets = sigSize / 4;

--- a/test_signature_options.js
+++ b/test_signature_options.js
@@ -1,0 +1,47 @@
+const { calculateSignatureOptions } = require('./src/signature_logic');
+
+function runTests() {
+    let allPassed = true;
+
+    function assertEqual(actual, expected, message) {
+        if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+            console.error(`❌ FAIL: ${message}`);
+            console.error(`Expected: ${JSON.stringify(expected)}`);
+            console.error(`Actual:   ${JSON.stringify(actual)}`);
+            allPassed = false;
+        } else {
+            console.log(`✅ PASS: ${message}`);
+        }
+    }
+
+    const availableSizes = [4, 8, 12, 16, 20, 24, 28, 32];
+
+    // Test 1: No flyleaf, exact match for 16
+    let result = calculateSignatureOptions(16, false, availableSizes);
+    assertEqual(result.bestSignatureSize, 16, "Best signature size for 16 pages (no flyleaf)");
+    assertEqual(result.options.find(o => o.sigSize === 16).blanksAdded, 0, "Blanks added for 16-page doc in 16-page sig");
+
+    // Test 2: No flyleaf, 14 pages
+    result = calculateSignatureOptions(14, false, availableSizes);
+    assertEqual(result.bestSignatureSize, 16, "Best signature size for 14 pages (no flyleaf)");
+    assertEqual(result.options.find(o => o.sigSize === 16).blanksAdded, 2, "Blanks added for 14-page doc in 16-page sig");
+
+    // Test 3: With flyleaf, 14 pages (effectively 16)
+    result = calculateSignatureOptions(14, true, availableSizes);
+    assertEqual(result.bestSignatureSize, 16, "Best signature size for 14 pages (with flyleaf)");
+    assertEqual(result.options.find(o => o.sigSize === 16).blanksAdded, 0, "Blanks added for 14-page doc with flyleaf in 16-page sig");
+
+    // Test 4: With flyleaf, 1 page (flyleaf not applied)
+    result = calculateSignatureOptions(1, true, availableSizes);
+    assertEqual(result.bestSignatureSize, 16, "Best signature size for 1 page (flyleaf disabled internally)");
+    assertEqual(result.options.find(o => o.sigSize === 16).blanksAdded, 15, "Blanks added for 1-page doc in 16-page sig");
+
+    if (allPassed) {
+        console.log("\n✅ ALL TESTS PASSED.");
+    } else {
+        console.error("\n❌ TESTS FAILED.");
+        process.exit(1);
+    }
+}
+
+runTests();


### PR DESCRIPTION
This addresses the issue regarding untested UI logic in `updateSignatureOptions` inside `index.html`. 
The core calculations for determining signature sizes, sheets, signatures, and total blanks have been extracted into `src/signature_logic.js`. 
Tests have been added in `test_signature_options.js` to cover different page counts and the flyleaf functionality. `index.html` has been updated to run the new script.

---
*PR created automatically by Jules for task [1225825722868355459](https://jules.google.com/task/1225825722868355459) started by @creuzerm*